### PR TITLE
feat(core): create ASG with launch template

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## What is cdk-k3s-cluster?
 
-`cdk-k3s-cluster` is a new JSII construct library for AWS CDK that deploys a scalable Kubernetes [K3s](https://k3s.io/) cluster on **Graviton2 Arm-based** (mg6) **Spot** instances with one ~~click~~ command on AWS.
+`cdk-k3s-cluster` is a new JSII construct library for AWS CDK that deploys a scalable Kubernetes [K3s](https://k3s.io/) cluster on **Graviton2 Arm-based** (mg6 by default) **Spot** instances with one ~~click~~ command on AWS.
 
 
 ## What problem does cdk-k3s-cluster solve?
@@ -170,17 +170,13 @@ Cleaning up the environment is as easy as running `cdk destroy` from where you l
 
 ## Known issues and limitations
 
-* First and foremost this is a learning experiment. I have done limited tests with it. 
+* First and foremost this is a learning experiment. We have done limited tests with it. 
 
-* Frankly I have not tested this beyond a mere `kubectl get nodes` test. Let alone trying anything like [arkade](https://github.com/alexellis/arkade) 
-
-* I have only tested this in `us-west-2`. It should work in other regions too but I haven't tried 
-
-* The instance type and size options for `spot` deployments are limited to `m6g.medium`, `m6g.large` and all the `t4g` sizes. You could easily add another instance type/size option by tweaking the PriceMap in `cdk-stack.ts` 
+* We have not tested this beyond a mere `kubectl get nodes` test. Let alone trying anything like [arkade](https://github.com/alexellis/arkade) 
 
 * `cdk-k3s-cluster` only deploys Arm-based instances. It would be trivial to add x86 based instances support but it's not there today 
 
-* All the control plane and worker nodes are deployed in public subnets and the SGs are fairly permissive in terms of "source". Picking private subnets would have probably broken the use case of deploying into the `default` VPC (which is handy). This prototype over-indexes more on deployment convenience and ease of use than on best practices. 
+* All the control plane and worker nodes are deployed in public subnets and the SGs are fairly permissive in terms of "source". Picking private subnets would have probably broken the use case of deploying into the `default` VPC (which is handy). This prototype over-indexes more on deployment convenience and ease of use than on best practices. Be mindful of that
 
 * The control plane instance always deploys `on-demand` while for worker nodes you can pick between `on-demand` and `Spot`
 

--- a/src/integ.default.ts
+++ b/src/integ.default.ts
@@ -1,5 +1,5 @@
 import * as k3s from './'
-import { App, Stack, CfnOutput } from '@aws-cdk/core';
+import { App, Stack, CfnOutput, RemovalPolicy } from '@aws-cdk/core';
 import * as ec2 from '@aws-cdk/aws-ec2';
 
 export class IntegTesting {
@@ -22,6 +22,7 @@ export class IntegTesting {
       workerMinCapacity: 1,
       workerInstanceType: new ec2.InstanceType('m6g.medium'),
       controlPlaneInstanceType: new ec2.InstanceType('m6g.medium'),
+      bucketRemovalPolicy: RemovalPolicy.DESTROY,
     })
     
     new CfnOutput(stack, 'EndpointURI', { value: cluster.endpointUri }); 

--- a/src/integ.default.ts
+++ b/src/integ.default.ts
@@ -19,7 +19,7 @@ export class IntegTesting {
     const cluster = new k3s.Cluster(stack, 'Cluster', {
       vpc,
       spotWorkerNodes: true,
-      workerMinCapacity: 3,
+      workerMinCapacity: 1,
       workerInstanceType: new ec2.InstanceType('m6g.medium'),
       controlPlaneInstanceType: new ec2.InstanceType('m6g.medium'),
     })

--- a/src/integ.default.ts
+++ b/src/integ.default.ts
@@ -26,6 +26,7 @@ export class IntegTesting {
     })
     
     new CfnOutput(stack, 'EndpointURI', { value: cluster.endpointUri }); 
+    new CfnOutput(stack, 'Region', { value: Stack.of(stack).region }); 
     this.stack = [ stack ]
   };
 }

--- a/test/__snapshots__/integ.snapshot.test.ts.snap
+++ b/test/__snapshots__/integ.snapshot.test.ts.snap
@@ -42,6 +42,11 @@ Object {
         ],
       },
     },
+    "Region": Object {
+      "Value": Object {
+        "Ref": "AWS::Region",
+      },
+    },
   },
   "Parameters": Object {
     "AssetParameters20e06317b2e4aa8c9a1052d2e0f40d4c738bc91399a9ea24aa2b1e013bfe584bArtifactHash6D2CA43C": Object {

--- a/test/__snapshots__/integ.snapshot.test.ts.snap
+++ b/test/__snapshots__/integ.snapshot.test.ts.snap
@@ -44,12 +44,67 @@ Object {
     },
   },
   "Parameters": Object {
+    "AssetParameters20e06317b2e4aa8c9a1052d2e0f40d4c738bc91399a9ea24aa2b1e013bfe584bArtifactHash6D2CA43C": Object {
+      "Description": "Artifact hash for asset \\"20e06317b2e4aa8c9a1052d2e0f40d4c738bc91399a9ea24aa2b1e013bfe584b\\"",
+      "Type": "String",
+    },
+    "AssetParameters20e06317b2e4aa8c9a1052d2e0f40d4c738bc91399a9ea24aa2b1e013bfe584bS3BucketD5770D8A": Object {
+      "Description": "S3 bucket for asset \\"20e06317b2e4aa8c9a1052d2e0f40d4c738bc91399a9ea24aa2b1e013bfe584b\\"",
+      "Type": "String",
+    },
+    "AssetParameters20e06317b2e4aa8c9a1052d2e0f40d4c738bc91399a9ea24aa2b1e013bfe584bS3VersionKey7334E3C3": Object {
+      "Description": "S3 key for asset version \\"20e06317b2e4aa8c9a1052d2e0f40d4c738bc91399a9ea24aa2b1e013bfe584b\\"",
+      "Type": "String",
+    },
+    "AssetParameters2c1b581102fff68e6f015e50b7a302bb30efc81eac18cd3461e293473ce10a0aArtifactHashB2575C75": Object {
+      "Description": "Artifact hash for asset \\"2c1b581102fff68e6f015e50b7a302bb30efc81eac18cd3461e293473ce10a0a\\"",
+      "Type": "String",
+    },
+    "AssetParameters2c1b581102fff68e6f015e50b7a302bb30efc81eac18cd3461e293473ce10a0aS3Bucket13334F1C": Object {
+      "Description": "S3 bucket for asset \\"2c1b581102fff68e6f015e50b7a302bb30efc81eac18cd3461e293473ce10a0a\\"",
+      "Type": "String",
+    },
+    "AssetParameters2c1b581102fff68e6f015e50b7a302bb30efc81eac18cd3461e293473ce10a0aS3VersionKey2BBAFB9D": Object {
+      "Description": "S3 key for asset version \\"2c1b581102fff68e6f015e50b7a302bb30efc81eac18cd3461e293473ce10a0a\\"",
+      "Type": "String",
+    },
+    "AssetParameters7b8f901e53744758131669f2606b340cd2b32759fbbfc3dd93fb3fa4d08d690aArtifactHash84962CBE": Object {
+      "Description": "Artifact hash for asset \\"7b8f901e53744758131669f2606b340cd2b32759fbbfc3dd93fb3fa4d08d690a\\"",
+      "Type": "String",
+    },
+    "AssetParameters7b8f901e53744758131669f2606b340cd2b32759fbbfc3dd93fb3fa4d08d690aS3Bucket24A39C33": Object {
+      "Description": "S3 bucket for asset \\"7b8f901e53744758131669f2606b340cd2b32759fbbfc3dd93fb3fa4d08d690a\\"",
+      "Type": "String",
+    },
+    "AssetParameters7b8f901e53744758131669f2606b340cd2b32759fbbfc3dd93fb3fa4d08d690aS3VersionKey0E38F1A8": Object {
+      "Description": "S3 key for asset version \\"7b8f901e53744758131669f2606b340cd2b32759fbbfc3dd93fb3fa4d08d690a\\"",
+      "Type": "String",
+    },
     "SsmParameterValueawsserviceamiamazonlinuxlatestamzn2amihvmarm64gp2C96584B6F00A464EAD1953AFF4B05118Parameter": Object {
       "Default": "/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-arm64-gp2",
       "Type": "AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>",
     },
   },
   "Resources": Object {
+    "ClusterCRdeleteS3ObjectProviderC81CA0D5": Object {
+      "DeletionPolicy": "Delete",
+      "DependsOn": Array [
+        "Clusterk3sBucket0ECC11AD",
+      ],
+      "Properties": Object {
+        "Bucket": Object {
+          "Ref": "Clusterk3sBucket0ECC11AD",
+        },
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "ClusterdeleteS3ObjectProviderframeworkonEvent1699789C",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::CloudFormation::CustomResource",
+      "UpdateReplacePolicy": "Delete",
+    },
     "ClusterWorkerAsgASGFC685DD3": Object {
       "DependsOn": Array [
         "Clusterk3scontrolplaneInstanceProfile86CC8202",
@@ -331,10 +386,157 @@ Object {
       },
       "Type": "AWS::EC2::LaunchTemplate",
     },
+    "ClusterdeleteS3ObjectProviderframeworkonEvent1699789C": Object {
+      "DependsOn": Array [
+        "ClusterdeleteS3ObjectProviderframeworkonEventServiceRoleDefaultPolicy203B225F",
+        "ClusterdeleteS3ObjectProviderframeworkonEventServiceRole139620D6",
+      ],
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Ref": "AssetParameters7b8f901e53744758131669f2606b340cd2b32759fbbfc3dd93fb3fa4d08d690aS3Bucket24A39C33",
+          },
+          "S3Key": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                Object {
+                  "Fn::Select": Array [
+                    0,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameters7b8f901e53744758131669f2606b340cd2b32759fbbfc3dd93fb3fa4d08d690aS3VersionKey0E38F1A8",
+                        },
+                      ],
+                    },
+                  ],
+                },
+                Object {
+                  "Fn::Select": Array [
+                    1,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameters7b8f901e53744758131669f2606b340cd2b32759fbbfc3dd93fb3fa4d08d690aS3VersionKey0E38F1A8",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            ],
+          },
+        },
+        "Description": "AWS CDK resource provider framework - onEvent (testing-stack/Cluster/deleteS3ObjectProvider)",
+        "Environment": Object {
+          "Variables": Object {
+            "USER_ON_EVENT_FUNCTION_ARN": Object {
+              "Fn::GetAtt": Array [
+                "ClusteronEventHandler0F98534A",
+                "Arn",
+              ],
+            },
+          },
+        },
+        "Handler": "framework.onEvent",
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "ClusterdeleteS3ObjectProviderframeworkonEventServiceRole139620D6",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs10.x",
+        "Timeout": 900,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "ClusterdeleteS3ObjectProviderframeworkonEventLogRetentionD68A9D72": Object {
+      "Properties": Object {
+        "LogGroupName": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "/aws/lambda/",
+              Object {
+                "Ref": "ClusterdeleteS3ObjectProviderframeworkonEvent1699789C",
+              },
+            ],
+          ],
+        },
+        "RetentionInDays": 1,
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "Custom::LogRetention",
+    },
+    "ClusterdeleteS3ObjectProviderframeworkonEventServiceRole139620D6": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "ClusterdeleteS3ObjectProviderframeworkonEventServiceRoleDefaultPolicy203B225F": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "lambda:InvokeFunction",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "ClusteronEventHandler0F98534A",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ClusterdeleteS3ObjectProviderframeworkonEventServiceRoleDefaultPolicy203B225F",
+        "Roles": Array [
+          Object {
+            "Ref": "ClusterdeleteS3ObjectProviderframeworkonEventServiceRole139620D6",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "Clusterk3sBucket0ECC11AD": Object {
-      "DeletionPolicy": "Retain",
+      "DeletionPolicy": "Delete",
       "Type": "AWS::S3::Bucket",
-      "UpdateReplacePolicy": "Retain",
+      "UpdateReplacePolicy": "Delete",
     },
     "Clusterk3scontrolplaneB59785BE": Object {
       "DependsOn": Array [
@@ -559,6 +761,269 @@ Object {
         },
       },
       "Type": "AWS::EC2::SecurityGroup",
+    },
+    "ClusteronEventHandler0F98534A": Object {
+      "DependsOn": Array [
+        "ClusteronEventHandlerServiceRoleDefaultPolicy776DDCC8",
+        "ClusteronEventHandlerServiceRole88510C92",
+      ],
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Ref": "AssetParameters2c1b581102fff68e6f015e50b7a302bb30efc81eac18cd3461e293473ce10a0aS3Bucket13334F1C",
+          },
+          "S3Key": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                Object {
+                  "Fn::Select": Array [
+                    0,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameters2c1b581102fff68e6f015e50b7a302bb30efc81eac18cd3461e293473ce10a0aS3VersionKey2BBAFB9D",
+                        },
+                      ],
+                    },
+                  ],
+                },
+                Object {
+                  "Fn::Select": Array [
+                    1,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameters2c1b581102fff68e6f015e50b7a302bb30efc81eac18cd3461e293473ce10a0aS3VersionKey2BBAFB9D",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            ],
+          },
+        },
+        "Handler": "index.on_event",
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "ClusteronEventHandlerServiceRole88510C92",
+            "Arn",
+          ],
+        },
+        "Runtime": "python3.8",
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "ClusteronEventHandlerServiceRole88510C92": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "ClusteronEventHandlerServiceRoleDefaultPolicy776DDCC8": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "s3:DeleteObject*",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "Clusterk3sBucket0ECC11AD",
+                        "Arn",
+                      ],
+                    },
+                    "/*",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "Clusterk3sBucket0ECC11AD",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "Clusterk3sBucket0ECC11AD",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ClusteronEventHandlerServiceRoleDefaultPolicy776DDCC8",
+        "Roles": Array [
+          Object {
+            "Ref": "ClusteronEventHandlerServiceRole88510C92",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aFD4BFC8A": Object {
+      "DependsOn": Array [
+        "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB",
+        "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB",
+      ],
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Ref": "AssetParameters20e06317b2e4aa8c9a1052d2e0f40d4c738bc91399a9ea24aa2b1e013bfe584bS3BucketD5770D8A",
+          },
+          "S3Key": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                Object {
+                  "Fn::Select": Array [
+                    0,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameters20e06317b2e4aa8c9a1052d2e0f40d4c738bc91399a9ea24aa2b1e013bfe584bS3VersionKey7334E3C3",
+                        },
+                      ],
+                    },
+                  ],
+                },
+                Object {
+                  "Fn::Select": Array [
+                    1,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameters20e06317b2e4aa8c9a1052d2e0f40d4c738bc91399a9ea24aa2b1e013bfe584bS3VersionKey7334E3C3",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            ],
+          },
+        },
+        "Handler": "index.handler",
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs10.x",
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "logs:PutRetentionPolicy",
+                "logs:DeleteRetentionPolicy",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRoleDefaultPolicyADDA7DEB",
+        "Roles": Array [
+          Object {
+            "Ref": "LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8aServiceRole9741ECFB",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
     },
     "Vpc8378EB38": Object {
       "Properties": Object {

--- a/test/__snapshots__/integ.snapshot.test.ts.snap
+++ b/test/__snapshots__/integ.snapshot.test.ts.snap
@@ -58,11 +58,19 @@ Object {
         "Clusterk3scontrolplaneB59785BE",
       ],
       "Properties": Object {
-        "LaunchConfigurationName": Object {
-          "Ref": "ClusterWorkerAsgLaunchConfig70B7BCB1",
+        "LaunchTemplate": Object {
+          "LaunchTemplateId": Object {
+            "Ref": "ClusterWorkerLaunchTemplate84D2244A",
+          },
+          "Version": Object {
+            "Fn::GetAtt": Array [
+              "ClusterWorkerLaunchTemplate84D2244A",
+              "LatestVersionNumber",
+            ],
+          },
         },
-        "MaxSize": "3",
-        "MinSize": "3",
+        "MaxSize": "1",
+        "MinSize": "1",
         "Tags": Array [
           Object {
             "Key": "Name",
@@ -266,43 +274,62 @@ Object {
             ],
           },
         ],
-        "SpotPrice": "0.0385",
         "UserData": Object {
-          "Fn::Base64": Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                "#!/bin/bash
-
-       #!/bin/bash
-       LOGFILE='/var/log/k3s.log'
-       curl -L -o k3s https://github.com/rancher/k3s/releases/download/v1.16.13%2Bk3s1/k3s-arm64
-       chmod +x k3s
-       echo the bucket name is ",
-                Object {
-                  "Ref": "Clusterk3sBucket0ECC11AD",
-                },
-                " 
-       aws s3 cp s3://",
-                Object {
-                  "Ref": "Clusterk3sBucket0ECC11AD",
-                },
-                "/node-token /node-token 
-       (./k3s agent --server https://",
-                Object {
-                  "Fn::GetAtt": Array [
-                    "Clusterk3scontrolplaneB59785BE",
-                    "PrivateIp",
-                  ],
-                },
-                ":6443        --token $(cat /node-token) 2>&1 | tee -a $LOGFILE || echo \\"failed\\" > $LOGFILE &)
-    ",
-              ],
-            ],
-          },
+          "Fn::Base64": "#!/bin/bash",
         },
       },
       "Type": "AWS::AutoScaling::LaunchConfiguration",
+    },
+    "ClusterWorkerLaunchTemplate84D2244A": Object {
+      "Properties": Object {
+        "LaunchTemplateData": Object {
+          "ImageId": Object {
+            "Ref": "SsmParameterValueawsserviceamiamazonlinuxlatestamzn2amihvmarm64gp2C96584B6F00A464EAD1953AFF4B05118Parameter",
+          },
+          "InstanceMarketOptions": Object {
+            "MarketType": "spot",
+            "SpotOptions": Object {
+              "SpotInstanceType": "one-time",
+            },
+          },
+          "InstanceType": "m6g.medium",
+          "UserData": Object {
+            "Fn::Base64": Object {
+              "Fn::Join": Array [
+                "",
+                Array [
+                  "#!/bin/bash
+
+          #!/bin/bash
+          LOGFILE='/var/log/k3s.log'
+          curl -L -o k3s https://github.com/rancher/k3s/releases/download/v1.16.13%2Bk3s1/k3s-arm64
+          chmod +x k3s
+          echo the bucket name is ",
+                  Object {
+                    "Ref": "Clusterk3sBucket0ECC11AD",
+                  },
+                  " 
+          aws s3 cp s3://",
+                  Object {
+                    "Ref": "Clusterk3sBucket0ECC11AD",
+                  },
+                  "/node-token /node-token 
+          (./k3s agent --server https://",
+                  Object {
+                    "Fn::GetAtt": Array [
+                      "Clusterk3scontrolplaneB59785BE",
+                      "PrivateIp",
+                    ],
+                  },
+                  ":6443           --token $(cat /node-token) 2>&1 | tee -a $LOGFILE || echo \\"failed\\" > $LOGFILE &)
+    ",
+                ],
+              ],
+            },
+          },
+        },
+      },
+      "Type": "AWS::EC2::LaunchTemplate",
     },
     "Clusterk3sBucket0ECC11AD": Object {
       "DeletionPolicy": "Retain",
@@ -472,7 +499,6 @@ Object {
     "Clusterk3scontrolplaneSGCFC3EC51": Object {
       "Properties": Object {
         "GroupDescription": "testing-stack/Cluster/k3s-controlplane-SG",
-        "GroupName": "k3s-controlplane-SG",
         "SecurityGroupEgress": Array [
           Object {
             "CidrIp": "0.0.0.0/0",
@@ -505,7 +531,6 @@ Object {
     "Clusterk3sworkerSGA0EEA026": Object {
       "Properties": Object {
         "GroupDescription": "testing-stack/Cluster/k3s-worker-SG",
-        "GroupName": "k3-worker-SG",
         "SecurityGroupEgress": Array [
           Object {
             "CidrIp": "0.0.0.0/0",

--- a/test/cluster.test.ts
+++ b/test/cluster.test.ts
@@ -17,9 +17,18 @@ test('create the default cluster', () => {
   expect(stack).toHaveResource('AWS::AutoScaling::AutoScalingGroup', {
     MaxSize: '3',
     MinSize: '3',
-    LaunchConfigurationName: {
-      Ref: 'ClusterWorkerAsgLaunchConfig70B7BCB1',
-    }})
+    LaunchTemplate: {
+      LaunchTemplateId: {
+        Ref: 'ClusterWorkerLaunchTemplate84D2244A',
+      },
+      Version: {
+        'Fn::GetAtt': [
+          'ClusterWorkerLaunchTemplate84D2244A',
+          'LatestVersionNumber',
+        ],
+      },
+    },
+  });
 
   expect(stack).toHaveResource('AWS::AutoScaling::LaunchConfiguration')
 });
@@ -51,12 +60,19 @@ test('support m6g instance types', () => {
   })
   // THEN
   // worker nodes ASG
-  expect(stack).toHaveResource('AWS::AutoScaling::LaunchConfiguration', {
-    ImageId: {
-      Ref: 'SsmParameterValueawsserviceamiamazonlinuxlatestamzn2amihvmarm64gp2C96584B6F00A464EAD1953AFF4B05118Parameter',
+  expect(stack).toHaveResourceLike('AWS::EC2::LaunchTemplate', {
+    LaunchTemplateData: {
+      ImageId: {
+        Ref: 'SsmParameterValueawsserviceamiamazonlinuxlatestamzn2amihvmarm64gp2C96584B6F00A464EAD1953AFF4B05118Parameter',
+      },
+      InstanceMarketOptions: {
+        MarketType: 'spot',
+        SpotOptions: {
+          SpotInstanceType: 'one-time',
+        },
+      },
+      InstanceType: 'm6g.medium',
     },
-    InstanceType: 'm6g.medium',
-    SpotPrice: '0.0385',
   });
   // control plane ec2
   expect(stack).toHaveResource('AWS::EC2::Instance', {
@@ -77,12 +93,19 @@ test('support t4g instance types', () => {
   })
   // THEN
   // worker nodes ASG
-  expect(stack).toHaveResource('AWS::AutoScaling::LaunchConfiguration', {
-    ImageId: {
-      Ref: 'SsmParameterValueawsserviceamiamazonlinuxlatestamzn2amihvmarm64gp2C96584B6F00A464EAD1953AFF4B05118Parameter',
+  expect(stack).toHaveResourceLike('AWS::EC2::LaunchTemplate', {
+    LaunchTemplateData: {
+      ImageId: {
+        Ref: 'SsmParameterValueawsserviceamiamazonlinuxlatestamzn2amihvmarm64gp2C96584B6F00A464EAD1953AFF4B05118Parameter',
+      },
+      InstanceMarketOptions: {
+        MarketType: 'spot',
+        SpotOptions: {
+          SpotInstanceType: 'one-time',
+        },
+      },
+      InstanceType: 't4g.medium',
     },
-    InstanceType: 't4g.medium',
-    SpotPrice: '0.0336',
   });
   // control plane ec2
   expect(stack).toHaveResource('AWS::EC2::Instance', {


### PR DESCRIPTION
feat(core): create ASG with launch template

This PR retires the `PriceMap` and allows us to deploy to any aws commercial regions where the specified instance types are available.

1. ASG now goes with Launch Template
2. `PriceMap` not required as Launch Template does not require the `spotPrice`
3. random security group name to avoid the conflict

Closes: #5 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
